### PR TITLE
build: add apple-darwin targets

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,6 @@ jobs:
   build-apple-darwin:
     name: Build Apple Darwin
     runs-on: macos-latest
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.job == 'all' || github.event.inputs.job == 'build-apple-darwin'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,17 +6,25 @@ on:
     branches: [main]
 
 jobs:
-  build-windows-linux:
-    name: Build Windows, Linux
-    runs-on: ubuntu-latest
+  build:
+    name: Build
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: win-amd64
             target: x86_64-pc-windows-gnu
+            os: ubuntu-latest
           - name: linux-amd64
             target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - name: macos-amd64
+            target: x86_64-apple-darwin
+            os: macos-latest
+          - name: macos-arm64
+            target: aarch64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Linux build dependencies
         if: matrix.name == 'linux-amd64'
@@ -42,62 +50,17 @@ jobs:
       - name: Build Binary
         run: cargo build --locked --release --target ${{ matrix.target }}
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - name: Rename Binary for target
+        if: matrix.name != 'win-amd64'
+        run: mv target/${{ matrix.target }}/release/mesh-thumbnail* target/${{ matrix.target }}/release/mesh-thumbnail-${{ matrix.target }}
+      # Pesky .exe suffix. There's probably a better way to do this.
+      - name: Rename Binary for Windows
         if: matrix.name == 'win-amd64'
-        with:
-          name: Windows-binary
-          path: |
-            target/${{ matrix.target }}/release/mesh-thumbnail.exe
+        run: mv target/${{ matrix.target }}/release/mesh-thumbnail.exe target/${{ matrix.target }}/release/mesh-thumbnail-${{ matrix.target }}.exe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: matrix.name == 'linux-amd64'
         with:
-          name: Linux-binary
+          name: ${{matrix.name}}-binary
           path: |
-            target/${{ matrix.target }}/release/mesh-thumbnail
-
-  build-apple-darwin:
-    name: Build Apple Darwin
-    runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: macos-amd64
-            target: x86_64-apple-darwin
-          - name: macos-arm64
-            target: aarch64-apple-darwin
-    steps:
-      - name: Checkout
-        uses: actions/checkout@master
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: "${{ matrix.target }}"
-
-      - name: Setup Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: "mesh-thumbnail-${{ matrix.target }}"
-
-      - name: Build Binary
-        run: cargo build --locked --release --target ${{ matrix.target }}
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        if: matrix.name == 'macos-amd64'
-        with:
-          name: MacOS-amd64-binary
-          path: |
-            target/${{ matrix.target }}/release/mesh-thumbnail
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        if: matrix.name == 'macos-arm64'
-        with:
-          name: MacOS-arm64-binary
-          path: |
-            target/${{ matrix.target }}/release/mesh-thumbnail
+            target/${{ matrix.target }}/release/mesh-thumbnail*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Rename Binary for target
         if: matrix.name != 'win-amd64'
-        run: mv target/${{ matrix.target }}/release/mesh-thumbnail* target/${{ matrix.target }}/release/mesh-thumbnail-${{ matrix.target }}
+        run: mv target/${{ matrix.target }}/release/mesh-thumbnail target/${{ matrix.target }}/release/mesh-thumbnail-${{ matrix.target }}
       # Pesky .exe suffix. There's probably a better way to do this.
       - name: Rename Binary for Windows
         if: matrix.name == 'win-amd64'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,8 +6,8 @@ on:
     branches: [main]
 
 jobs:
-  build:
-    name: Build
+  build-windows-linux:
+    name: Build Windows, Linux
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -17,6 +17,10 @@ jobs:
             target: x86_64-pc-windows-gnu
           - name: linux-amd64
             target: x86_64-unknown-linux-gnu
+          - name: macos-amd64
+            target: x86_64-apple-darwin
+          - name: macos-arm64
+            target: aarch64-apple-darwin
     steps:
       - name: Linux build dependencies
         if: matrix.name == 'linux-amd64'
@@ -42,18 +46,77 @@ jobs:
       - name: Build Binary
         run: cargo build --locked --release --target ${{ matrix.target }}
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        if: matrix.name == 'win-amd64'
-        with:
-          name: Windows-binary
-          path: |
-            target/${{ matrix.target }}/release/mesh-thumbnail.exe
+      # - name: Upload artifact
+      #   uses: actions/upload-artifact@v4
+      #   if: matrix.name == 'win-amd64'
+      #   with:
+      #     name: Windows-binary
+      #     path: |
+      #       target/${{ matrix.target }}/release/mesh-thumbnail.exe
+
+      # - name: Upload artifact
+      #   uses: actions/upload-artifact@v4
+      #   if: matrix.name == 'linux-amd64'
+      #   with:
+      #     name: Linux-binary
+      #     path: |
+      #       target/${{ matrix.target }}/release/mesh-thumbnail
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: matrix.name == 'linux-amd64'
+        if: matrix.name == 'macos-amd64'
         with:
-          name: Linux-binary
+          name: MacOS-amd64-binary
+          path: |
+            target/${{ matrix.target }}/release/mesh-thumbnail
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'macos-arm64'
+        with:
+          name: MacOS-arm64-binary
+          path: |
+            target/${{ matrix.target }}/release/mesh-thumbnail
+  build-apple-darwin:
+    name: Build Apple Darwin
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macos-amd64
+            target: x86_64-apple-darwin
+          - name: macos-arm64
+            target: aarch64-apple-darwin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: "${{ matrix.target }}"
+
+      - name: Setup Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "mesh-thumbnail-${{ matrix.target }}"
+
+      - name: Build Binary
+        run: cargo build --locked --release --target ${{ matrix.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'macos-amd64'
+        with:
+          name: MacOS-amd64-binary
+          path: |
+            target/${{ matrix.target }}/release/mesh-thumbnail
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'macos-arm64'
+        with:
+          name: MacOS-arm64-binary
           path: |
             target/${{ matrix.target }}/release/mesh-thumbnail

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,15 @@ name: Build
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      job:
+        description: 'Job to run'
+        required: true
+        type: choice
+        options:
+          - build-apple-darwin
+          - all
 
 jobs:
   build-windows-linux:
@@ -17,10 +26,6 @@ jobs:
             target: x86_64-pc-windows-gnu
           - name: linux-amd64
             target: x86_64-unknown-linux-gnu
-          - name: macos-amd64
-            target: x86_64-apple-darwin
-          - name: macos-arm64
-            target: aarch64-apple-darwin
     steps:
       - name: Linux build dependencies
         if: matrix.name == 'linux-amd64'
@@ -46,40 +51,26 @@ jobs:
       - name: Build Binary
         run: cargo build --locked --release --target ${{ matrix.target }}
 
-      # - name: Upload artifact
-      #   uses: actions/upload-artifact@v4
-      #   if: matrix.name == 'win-amd64'
-      #   with:
-      #     name: Windows-binary
-      #     path: |
-      #       target/${{ matrix.target }}/release/mesh-thumbnail.exe
-
-      # - name: Upload artifact
-      #   uses: actions/upload-artifact@v4
-      #   if: matrix.name == 'linux-amd64'
-      #   with:
-      #     name: Linux-binary
-      #     path: |
-      #       target/${{ matrix.target }}/release/mesh-thumbnail
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'win-amd64'
+        with:
+          name: Windows-binary
+          path: |
+            target/${{ matrix.target }}/release/mesh-thumbnail.exe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: matrix.name == 'macos-amd64'
+        if: matrix.name == 'linux-amd64'
         with:
-          name: MacOS-amd64-binary
+          name: Linux-binary
           path: |
             target/${{ matrix.target }}/release/mesh-thumbnail
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        if: matrix.name == 'macos-arm64'
-        with:
-          name: MacOS-arm64-binary
-          path: |
-            target/${{ matrix.target }}/release/mesh-thumbnail
   build-apple-darwin:
     name: Build Apple Darwin
     runs-on: macos-latest
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.job == 'all' || github.event.inputs.job == 'build-apple-darwin'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,8 +6,8 @@ on:
     branches: [main]
 
 jobs:
-  build:
-    name: Build
+  build-windows-linux:
+    name: Build Windows, Linux
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -55,5 +55,50 @@ jobs:
         if: matrix.name == 'linux-amd64'
         with:
           name: Linux-binary
+          path: |
+            target/${{ matrix.target }}/release/mesh-thumbnail
+
+  build-apple-darwin:
+    name: Build Apple Darwin
+    runs-on: macos-latest
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.job == 'all' || github.event.inputs.job == 'build-apple-darwin'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macos-amd64
+            target: x86_64-apple-darwin
+          - name: macos-arm64
+            target: aarch64-apple-darwin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: "${{ matrix.target }}"
+
+      - name: Setup Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "mesh-thumbnail-${{ matrix.target }}"
+
+      - name: Build Binary
+        run: cargo build --locked --release --target ${{ matrix.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'macos-amd64'
+        with:
+          name: MacOS-amd64-binary
+          path: |
+            target/${{ matrix.target }}/release/mesh-thumbnail
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'macos-arm64'
+        with:
+          name: MacOS-arm64-binary
           path: |
             target/${{ matrix.target }}/release/mesh-thumbnail

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,15 +4,6 @@ name: Build
 on:
   push:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      job:
-        description: 'Job to run'
-        required: true
-        type: choice
-        options:
-          - build-apple-darwin
-          - all
 
 jobs:
   build-windows-linux:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - name: win-amd64
-            target: x86_64-pc-windows-gnu
+            target: x86_64-pc-windows-msvc
             os: ubuntu-latest
           - name: linux-amd64
             target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
I'd like to use `mesh-organizer` on a mac. I noticed in https://github.com/suchmememanyskill/mesh-organiser/issues/1#issuecomment-2780972126 that one of the required steps would be making sure that `mesh-thumbnail` works on Apple hardware.

I pulled it down, builds fine, and I confirmed the aarch64 version works great. 

This PR adds workflows to build apple-darwin targets. 

You can see the workflow executions and grab the built binaries from https://github.com/logikal/mesh-thumbnail/actions/runs/14349635694