### PR TITLE
Add macos support, other build/release improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,6 @@ jobs:
   build-apple-darwin:
     name: Build Apple Darwin
     runs-on: macos-latest
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.job == 'all' || github.event.inputs.job == 'build-apple-darwin'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,17 +6,25 @@ on:
     branches: [main]
 
 jobs:
-  build-windows-linux:
-    name: Build Windows, Linux
-    runs-on: ubuntu-latest
+  build:
+    name: Build
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: win-amd64
             target: x86_64-pc-windows-gnu
+            os: ubuntu-latest
           - name: linux-amd64
             target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - name: macos-amd64
+            target: x86_64-apple-darwin
+            os: macos-latest
+          - name: macos-arm64
+            target: aarch64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Linux build dependencies
         if: matrix.name == 'linux-amd64'
@@ -42,62 +50,17 @@ jobs:
       - name: Build Binary
         run: cargo build --locked --release --target ${{ matrix.target }}
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - name: Rename Binary for target
+        if: matrix.name != 'win-amd64'
+        run: mv target/${{ matrix.target }}/release/mesh-thumbnail* target/${{ matrix.target }}/release/mesh-thumbnail-${{ matrix.target }}
+      # Pesky .exe suffix. There's probably a better way to do this.
+      - name: Rename Binary for Windows
         if: matrix.name == 'win-amd64'
-        with:
-          name: Windows-binary
-          path: |
-            target/${{ matrix.target }}/release/mesh-thumbnail.exe
+        run: mv target/${{ matrix.target }}/release/mesh-thumbnail.exe target/${{ matrix.target }}/release/mesh-thumbnail-${{ matrix.target }}.exe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: matrix.name == 'linux-amd64'
         with:
-          name: Linux-binary
+          name: ${{matrix.name}}-binary
           path: |
-            target/${{ matrix.target }}/release/mesh-thumbnail
-
-  build-apple-darwin:
-    name: Build Apple Darwin
-    runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: macos-amd64
-            target: x86_64-apple-darwin
-          - name: macos-arm64
-            target: aarch64-apple-darwin
-    steps:
-      - name: Checkout
-        uses: actions/checkout@master
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: "${{ matrix.target }}"
-
-      - name: Setup Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: "mesh-thumbnail-${{ matrix.target }}"
-
-      - name: Build Binary
-        run: cargo build --locked --release --target ${{ matrix.target }}
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        if: matrix.name == 'macos-amd64'
-        with:
-          name: MacOS-amd64-binary
-          path: |
-            target/${{ matrix.target }}/release/mesh-thumbnail
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        if: matrix.name == 'macos-arm64'
-        with:
-          name: MacOS-arm64-binary
-          path: |
-            target/${{ matrix.target }}/release/mesh-thumbnail
+            target/${{ matrix.target }}/release/mesh-thumbnail*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - name: win-amd64
-            target: x86_64-pc-windows-msvc
+            target: x86_64-pc-windows-gnu
             os: ubuntu-latest
           - name: linux-amd64
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Rename Binary for target
         if: matrix.name != 'win-amd64'
-        run: mv target/${{ matrix.target }}/release/mesh-thumbnail* target/${{ matrix.target }}/release/mesh-thumbnail-${{ matrix.target }}
+        run: mv target/${{ matrix.target }}/release/mesh-thumbnail target/${{ matrix.target }}/release/mesh-thumbnail-${{ matrix.target }}
       # Pesky .exe suffix. There's probably a better way to do this.
       - name: Rename Binary for Windows
         if: matrix.name == 'win-amd64'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,8 +34,6 @@ jobs:
             target: aarch64-apple-darwin
             os: macos-latest
     runs-on: ${{ matrix.os }}
-    outputs:
-      artifacts: ${{ steps.upload.outputs.artifact_path }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,8 +6,8 @@ on:
     branches: [main]
 
 jobs:
-  build:
-    name: Build
+  build-windows-linux:
+    name: Build Windows, Linux
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -17,6 +17,10 @@ jobs:
             target: x86_64-pc-windows-gnu
           - name: linux-amd64
             target: x86_64-unknown-linux-gnu
+          - name: macos-amd64
+            target: x86_64-apple-darwin
+          - name: macos-arm64
+            target: aarch64-apple-darwin
     steps:
       - name: Linux build dependencies
         if: matrix.name == 'linux-amd64'
@@ -42,18 +46,77 @@ jobs:
       - name: Build Binary
         run: cargo build --locked --release --target ${{ matrix.target }}
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        if: matrix.name == 'win-amd64'
-        with:
-          name: Windows-binary
-          path: |
-            target/${{ matrix.target }}/release/mesh-thumbnail.exe
+      # - name: Upload artifact
+      #   uses: actions/upload-artifact@v4
+      #   if: matrix.name == 'win-amd64'
+      #   with:
+      #     name: Windows-binary
+      #     path: |
+      #       target/${{ matrix.target }}/release/mesh-thumbnail.exe
+
+      # - name: Upload artifact
+      #   uses: actions/upload-artifact@v4
+      #   if: matrix.name == 'linux-amd64'
+      #   with:
+      #     name: Linux-binary
+      #     path: |
+      #       target/${{ matrix.target }}/release/mesh-thumbnail
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: matrix.name == 'linux-amd64'
+        if: matrix.name == 'macos-amd64'
         with:
-          name: Linux-binary
+          name: MacOS-amd64-binary
+          path: |
+            target/${{ matrix.target }}/release/mesh-thumbnail
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'macos-arm64'
+        with:
+          name: MacOS-arm64-binary
+          path: |
+            target/${{ matrix.target }}/release/mesh-thumbnail
+  build-apple-darwin:
+    name: Build Apple Darwin
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macos-amd64
+            target: x86_64-apple-darwin
+          - name: macos-arm64
+            target: aarch64-apple-darwin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: "${{ matrix.target }}"
+
+      - name: Setup Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "mesh-thumbnail-${{ matrix.target }}"
+
+      - name: Build Binary
+        run: cargo build --locked --release --target ${{ matrix.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'macos-amd64'
+        with:
+          name: MacOS-amd64-binary
+          path: |
+            target/${{ matrix.target }}/release/mesh-thumbnail
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'macos-arm64'
+        with:
+          name: MacOS-arm64-binary
           path: |
             target/${{ matrix.target }}/release/mesh-thumbnail

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,15 @@ name: Build
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      job:
+        description: 'Job to run'
+        required: true
+        type: choice
+        options:
+          - build-apple-darwin
+          - all
 
 jobs:
   build-windows-linux:
@@ -17,10 +26,6 @@ jobs:
             target: x86_64-pc-windows-gnu
           - name: linux-amd64
             target: x86_64-unknown-linux-gnu
-          - name: macos-amd64
-            target: x86_64-apple-darwin
-          - name: macos-arm64
-            target: aarch64-apple-darwin
     steps:
       - name: Linux build dependencies
         if: matrix.name == 'linux-amd64'
@@ -46,40 +51,26 @@ jobs:
       - name: Build Binary
         run: cargo build --locked --release --target ${{ matrix.target }}
 
-      # - name: Upload artifact
-      #   uses: actions/upload-artifact@v4
-      #   if: matrix.name == 'win-amd64'
-      #   with:
-      #     name: Windows-binary
-      #     path: |
-      #       target/${{ matrix.target }}/release/mesh-thumbnail.exe
-
-      # - name: Upload artifact
-      #   uses: actions/upload-artifact@v4
-      #   if: matrix.name == 'linux-amd64'
-      #   with:
-      #     name: Linux-binary
-      #     path: |
-      #       target/${{ matrix.target }}/release/mesh-thumbnail
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'win-amd64'
+        with:
+          name: Windows-binary
+          path: |
+            target/${{ matrix.target }}/release/mesh-thumbnail.exe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: matrix.name == 'macos-amd64'
+        if: matrix.name == 'linux-amd64'
         with:
-          name: MacOS-amd64-binary
+          name: Linux-binary
           path: |
             target/${{ matrix.target }}/release/mesh-thumbnail
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        if: matrix.name == 'macos-arm64'
-        with:
-          name: MacOS-arm64-binary
-          path: |
-            target/${{ matrix.target }}/release/mesh-thumbnail
   build-apple-darwin:
     name: Build Apple Darwin
     runs-on: macos-latest
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.job == 'all' || github.event.inputs.job == 'build-apple-darwin'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,8 +6,8 @@ on:
     branches: [main]
 
 jobs:
-  build:
-    name: Build
+  build-windows-linux:
+    name: Build Windows, Linux
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -55,5 +55,50 @@ jobs:
         if: matrix.name == 'linux-amd64'
         with:
           name: Linux-binary
+          path: |
+            target/${{ matrix.target }}/release/mesh-thumbnail
+
+  build-apple-darwin:
+    name: Build Apple Darwin
+    runs-on: macos-latest
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.job == 'all' || github.event.inputs.job == 'build-apple-darwin'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macos-amd64
+            target: x86_64-apple-darwin
+          - name: macos-arm64
+            target: aarch64-apple-darwin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: "${{ matrix.target }}"
+
+      - name: Setup Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "mesh-thumbnail-${{ matrix.target }}"
+
+      - name: Build Binary
+        run: cargo build --locked --release --target ${{ matrix.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'macos-amd64'
+        with:
+          name: MacOS-amd64-binary
+          path: |
+            target/${{ matrix.target }}/release/mesh-thumbnail
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: matrix.name == 'macos-arm64'
+        with:
+          name: MacOS-arm64-binary
           path: |
             target/${{ matrix.target }}/release/mesh-thumbnail

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,6 +45,14 @@ jobs:
         with:
           targets: "${{ matrix.target }}"
 
+      - name: Linux build dependencies
+        if: matrix.name == 'linux-amd64'
+        run: sudo apt install fontconfig libfontconfig-dev -y
+
+      - name: Windows build dependencies
+        if: matrix.name == 'win-amd64'
+        run: sudo apt-get install -y gcc-mingw-w64-x86-64
+
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: ${{matrix.name}}-binary
           path: |
-            target/${{ matrix.target }}/release/mesh-thumbnail*
+            target/${{ matrix.target }}/release/mesh-thumbnail-${{ matrix.target }}*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,10 +5,6 @@ on:
   push:
     branches: [main]
   workflow_call:
-    outputs:
-      artifacts:
-        description: 'Path to the built artifacts'
-        value: ${{ jobs.build.outputs.artifacts }}
 
 permissions:
   contents: read    # Required by actions/checkout@v4 to clone the repository

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,15 +4,6 @@ name: Build
 on:
   push:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      job:
-        description: 'Job to run'
-        required: true
-        type: choice
-        options:
-          - build-apple-darwin
-          - all
 
 jobs:
   build-windows-linux:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - name: win-amd64
-            target: x86_64-pc-windows-gnu
+            target: x86_64-pc-windows-msvc
             os: ubuntu-latest
           - name: linux-amd64
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,15 @@ name: Build
 on:
   push:
     branches: [main]
+  workflow_call:
+    outputs:
+      artifacts:
+        description: 'Path to the built artifacts'
+        value: ${{ jobs.build.outputs.artifacts }}
+
+permissions:
+  contents: read    # Required by actions/checkout@v4 to clone the repository
+  id-token: write   # Required by Swatinem/rust-cache@v2 for OIDC authentication with the cache service
 
 jobs:
   build:
@@ -25,17 +34,11 @@ jobs:
             target: aarch64-apple-darwin
             os: macos-latest
     runs-on: ${{ matrix.os }}
+    outputs:
+      artifacts: ${{ steps.upload.outputs.artifact_path }}
     steps:
-      - name: Linux build dependencies
-        if: matrix.name == 'linux-amd64'
-        run: sudo apt install fontconfig libfontconfig-dev -y
-
-      - name: Windows build dependencies
-        if: matrix.name == 'win-amd64'
-        run: sudo apt-get install -y gcc-mingw-w64-x86-64
-
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -59,6 +62,7 @@ jobs:
         run: mv target/${{ matrix.target }}/release/mesh-thumbnail.exe target/${{ matrix.target }}/release/mesh-thumbnail-${{ matrix.target }}.exe
 
       - name: Upload artifact
+        id: upload
         uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.name}}-binary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to release from'
+        required: true
+        type: string
+        default: 'main'
+      version:
+        description: 'Version to release (e.g., 1.0.0). If not provided, will be inferred from the latest tag.'
+        required: false
+        type: string
+      draft:
+        description: 'Create as draft release'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write    # Required by softprops/action-gh-release@v2 to create releases and upload artifacts
+  id-token: write    # Required by actions/attest@v2 for OIDC authentication with the attestation service
+  attestations: write # Required by actions/attest@v2 to create and store attestations
+
+jobs:
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yaml
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ needs.build.outputs.artifacts }}
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.event.inputs.version || github.ref_name }}
+          draft: ${{ github.event.inputs.draft || false }}
+          prerelease: false
+          generate_release_notes: true
+          files: ${{ needs.build.outputs.artifacts }}/**/*
+
+      - name: Attest Release
+        uses: actions/attest@v2
+        with:
+          subject-path: ${{ needs.build.outputs.artifacts }}/**/*
+          predicate-type: 'https://in-toto.io/attestation/release/v0.1'
+          predicate: |
+            {
+              "version": "${{ github.event.inputs.version || github.ref_name }}",
+              "commit": "${{ github.sha }}",
+              "branch": "${{ github.event.inputs.branch || github.ref_name }}"
+            }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          path: ${{ needs.build.outputs.artifacts }}
+          path: artifacts
 
       - name: Create Release
         id: create_release
@@ -49,12 +49,12 @@ jobs:
           draft: ${{ github.event.inputs.draft || false }}
           prerelease: false
           generate_release_notes: true
-          files: ${{ needs.build.outputs.artifacts }}/**/*
+          files: artifacts/**/*
 
       - name: Attest Release
         uses: actions/attest@v2
         with:
-          subject-path: ${{ needs.build.outputs.artifacts }}/**/*
+          subject-path: artifacts/**/*
           predicate-type: 'https://in-toto.io/attestation/release/v0.1'
           predicate: |
             {


### PR DESCRIPTION
# Add macOS Support and Release Workflow

This PR adds macOS support and introduces a release workflow for artifact distribution.

I wanted to use [mesh-organiser](https://github.com/suchmememanyskill/mesh-organiser) on macos, and getting `mesh-thumbnail` working there was a required first step.

I may have gotten a little carried away with smoothing out the release process for consumption by `mesh-organizer`.


## macOS Support
- Added support for both Intel and Apple Silicon Macs:
  - `x86_64-apple-darwin` (Intel) (untested)
  - `aarch64-apple-darwin` (Apple Silicon)
- Consistent binary naming across all platforms
- Target-specific builds

## Release Workflow
- Automated releases on version tags
- Individual binary downloads
- Automatic release notes generation
- Release attestation for security
- Manual release option

You can see what the filenames and artifacts from the build look like in my [fake release ](https://github.com/logikal/mesh-thumbnail/releases), or in the most recent [Workflow logs](https://github.com/logikal/mesh-thumbnail/actions/runs/14421621878)
